### PR TITLE
Remove dependency on "image" package.

### DIFF
--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 Future<Uint8List> blurHashDecode({
@@ -36,6 +37,7 @@ Future<Uint8List> blurHashDecode({
   final bytesPerRow = width * 4;
   final pixels = Uint8List(bytesPerRow * height);
 
+  int p = 0;
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       var r = .0;
@@ -56,10 +58,10 @@ Future<Uint8List> blurHashDecode({
       final intG = _linearTosRGB(g);
       final intB = _linearTosRGB(b);
 
-      pixels[4 * x + 0 + y * bytesPerRow] = intR;
-      pixels[4 * x + 1 + y * bytesPerRow] = intG;
-      pixels[4 * x + 2 + y * bytesPerRow] = intB;
-      pixels[4 * x + 3 + y * bytesPerRow] = 255;
+      pixels[p++] = intR;
+      pixels[p++] = intG;
+      pixels[p++] = intB;
+      pixels[p++] = 255;
     }
   }
 
@@ -78,7 +80,7 @@ Future<ui.Image> blurHashDecodeImage({
   final completer = Completer<ui.Image>();
 
   blurHashDecode(blurHash: blurHash, width: width, height: height, punch: punch)
-      .then((pixels) => ui.decodeImageFromPixels(Uint8List.view(pixels.buffer),
+      .then((pixels) => ui.decodeImageFromPixels(pixels,
           width, height, ui.PixelFormat.rgba8888, completer.complete));
 
   return completer.future;
@@ -160,3 +162,23 @@ List _decodeAC(int value, double maximumValue) {
 
 const _digitCharacters =
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#\$%*+,-.:;=?@[]^_{|}~";
+
+class Style {
+  final String name;
+  final List<ui.Color> colors;
+  final ui.Color stroke;
+  final ui.Color background;
+
+  const Style({this.name, this.colors, this.stroke, this.background});
+}
+
+const styles = {
+  'flourish': [
+    Style(
+      name: 'one',
+      colors: [],
+      stroke: null,
+      background: null,
+    )
+  ]
+};

--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -162,23 +162,3 @@ List _decodeAC(int value, double maximumValue) {
 
 const _digitCharacters =
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#\$%*+,-.:;=?@[]^_{|}~";
-
-class Style {
-  final String name;
-  final List<ui.Color> colors;
-  final ui.Color stroke;
-  final ui.Color background;
-
-  const Style({this.name, this.colors, this.stroke, this.background});
-}
-
-const styles = {
-  'flourish': [
-    Style(
-      name: 'one',
-      colors: [],
-      stroke: null,
-      background: null,
-    )
-  ]
-};

--- a/lib/src/blurhash_image.dart
+++ b/lib/src/blurhash_image.dart
@@ -1,8 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
-import 'dart:ui' as ui show Codec;
-import 'dart:ui' show hashValues;
-import 'package:image/image.dart' as graphics;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
@@ -14,10 +10,7 @@ class BlurHashImage extends ImageProvider<BlurHashImage> {
   /// Creates an object that decodes a [blurHash] as an image.
   ///
   /// The arguments must not be null.
-  const BlurHashImage(this.blurHash,
-      {this.decodingWidth = _DEFAULT_SIZE,
-      this.decodingHeight = _DEFAULT_SIZE,
-      this.scale = 1.0})
+  const BlurHashImage(this.blurHash, {this.decodingWidth = _DEFAULT_SIZE, this.decodingHeight = _DEFAULT_SIZE, this.scale = 1.0})
       : assert(blurHash != null),
         assert(scale != null);
 
@@ -40,32 +33,24 @@ class BlurHashImage extends ImageProvider<BlurHashImage> {
 
   @override
   ImageStreamCompleter load(BlurHashImage key, DecoderCallback decode) {
-    return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode),
-      scale: key.scale,
-    );
+    return OneFrameImageStreamCompleter(_loadAsync(key));
   }
 
-  Future<ui.Codec> _loadAsync(BlurHashImage key, DecoderCallback decode) async {
+  Future<ImageInfo> _loadAsync(BlurHashImage key) async {
     assert(key == this);
 
-    var bytes = await blurHashDecode(
+    var image = await blurHashDecodeImage(
       blurHash: blurHash,
       width: decodingWidth,
       height: decodingHeight,
-    ).then((rs) {
-      final img = graphics.Image.fromBytes(decodingWidth, decodingHeight, rs);
-      return Uint8List.fromList(graphics.encodePng(img));
-    });
-    return decode(bytes);
+    );
+   return ImageInfo(image: image, scale: key.scale);
   }
 
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
-    return other is BlurHashImage &&
-        other.blurHash == blurHash &&
-        other.scale == scale;
+    return other is BlurHashImage && other.blurHash == blurHash && other.scale == scale;
   }
 
   @override


### PR DESCRIPTION
As we discussed it with Rene at https://github.com/Baseflow/flutter_cached_network_image/issues/386, there is no need to depend on `image` for the conversion of pixel data to image, the Skia inside the Flutter framework can do it directly. These are the necessary changes. It works on mobile, I still have some problems on Flutter Web (it looks like `ui.decodeImageFromPixels()` simply never returns), so expect more to come.

Sorry for the inclusion of class `Style`, I don't know how Android Studio pulled that off. I simply forked, modified, committed and pushed. :-)