### PR TITLE
#24 Build with Dart 2.12 and null-safety

### DIFF
--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -4,16 +4,13 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 Future<Uint8List> blurHashDecode({
-  @required String blurHash,
-  @required int width,
-  @required int height,
+  required String blurHash,
+  required int width,
+  required int height,
   double punch = 1.0,
 }) {
-  assert(blurHash != null && width != null && height != null && punch != null);
   _validateBlurHash(blurHash);
 
   final sizeFlag = _decode83(blurHash[0]);
@@ -23,7 +20,7 @@ Future<Uint8List> blurHashDecode({
   final quantisedMaximumValue = _decode83(blurHash[1]);
   final maximumValue = (quantisedMaximumValue + 1) / 166;
 
-  final colors = List(numX * numY);
+  final colors = []..length = numX * numY;
 
   for (var i = 0; i < colors.length; i++) {
     if (i == 0) {
@@ -70,24 +67,26 @@ Future<Uint8List> blurHashDecode({
 }
 
 Future<ui.Image> blurHashDecodeImage({
-  @required String blurHash,
-  @required int width,
-  @required int height,
+  required String blurHash,
+  required int width,
+  required int height,
   double punch = 1.0,
 }) async {
-  assert(blurHash != null && width != null && height != null && punch != null);
   _validateBlurHash(blurHash);
 
   final completer = Completer<ui.Image>();
 
   if (kIsWeb) {
     // https://github.com/flutter/flutter/issues/45190
-    final pixels = await blurHashDecode(blurHash: blurHash, width: width, height: height, punch: punch);
+    final pixels = await blurHashDecode(
+        blurHash: blurHash, width: width, height: height, punch: punch);
     completer.complete(_createBmp(pixels, width, height));
-  }
-  else {
-    blurHashDecode(blurHash: blurHash, width: width, height: height, punch: punch).then((pixels) {
-      ui.decodeImageFromPixels(pixels, width, height, ui.PixelFormat.rgba8888, completer.complete);
+  } else {
+    blurHashDecode(
+            blurHash: blurHash, width: width, height: height, punch: punch)
+        .then((pixels) {
+      ui.decodeImageFromPixels(
+          pixels, width, height, ui.PixelFormat.rgba8888, completer.complete);
     });
   }
 
@@ -124,7 +123,7 @@ double _sRGBToLinear(int value) {
   if (v <= 0.04045) {
     return v / 12.92;
   } else {
-    return pow((v + 0.055) / 1.055, 2.4);
+    return pow((v + 0.055) / 1.055, 2.4) as double;
   }
 }
 
@@ -138,7 +137,7 @@ int _linearTosRGB(double value) {
 }
 
 void _validateBlurHash(String blurHash) {
-  if (blurHash == null || blurHash.length < 6) {
+  if (blurHash.length < 6) {
     throw Exception('The blurhash string must be at least 6 characters');
   }
 
@@ -155,7 +154,7 @@ void _validateBlurHash(String blurHash) {
 
 int _sign(double n) => (n < 0 ? -1 : 1);
 
-double _signPow(double val, double exp) => _sign(val) * pow(val.abs(), exp);
+num _signPow(double val, double exp) => _sign(val) * pow(val.abs(), exp);
 
 int _decode83(String str) {
   var value = 0;
@@ -172,19 +171,19 @@ int _decode83(String str) {
   return value;
 }
 
-List _decodeDC(int value) {
+List<double> _decodeDC(int value) {
   final intR = value >> 16;
   final intG = (value >> 8) & 255;
   final intB = value & 255;
   return [_sRGBToLinear(intR), _sRGBToLinear(intG), _sRGBToLinear(intB)];
 }
 
-List _decodeAC(int value, double maximumValue) {
+List<double> _decodeAC(int value, double maximumValue) {
   final quantR = (value / (19 * 19)).floor();
   final quantG = (value / 19).floor() % 19;
   final quantB = value % 19;
 
-  final List rgb = [
+  final rgb = [
     _signPow((quantR - 9) / 9, 2.0) * maximumValue,
     _signPow((quantG - 9) / 9, 2.0) * maximumValue,
     _signPow((quantB - 9) / 9, 2.0) * maximumValue
@@ -199,10 +198,11 @@ const _digitCharacters =
 class Style {
   final String name;
   final List<ui.Color> colors;
-  final ui.Color stroke;
-  final ui.Color background;
+  final ui.Color? stroke;
+  final ui.Color? background;
 
-  const Style({this.name, this.colors, this.stroke, this.background});
+  const Style(
+      {required this.name, required this.colors, this.stroke, this.background});
 }
 
 const styles = {

--- a/lib/src/blurhash_widget.dart
+++ b/lib/src/blurhash_widget.dart
@@ -9,8 +9,8 @@ const _DEFAULT_SIZE = 32;
 /// Display a Hash then fade to Image
 class BlurHash extends StatefulWidget {
   const BlurHash({
-    Key key,
-    @required this.hash,
+    required this.hash,
+    Key? key,
     this.color = Colors.blueGrey,
     this.imageFit = BoxFit.fill,
     this.decodingWidth = _DEFAULT_SIZE,
@@ -21,21 +21,18 @@ class BlurHash extends StatefulWidget {
     this.onStarted,
     this.duration = const Duration(milliseconds: 1000),
     this.curve = Curves.easeOut,
-  })  : assert(color != null),
-        assert(hash != null),
-        assert(duration != null),
-        assert(decodingWidth > 0),
+  })  : assert(decodingWidth > 0),
         assert(decodingHeight != 0),
         super(key: key);
 
   /// Callback when hash is decoded
-  final VoidCallback onDecoded;
+  final VoidCallback? onDecoded;
 
   /// Callback when image is downloaded
-  final VoidCallback onReady;
+  final VoidCallback? onReady;
 
   /// Callback when image is downloaded
-  final VoidCallback onStarted;
+  final VoidCallback? onStarted;
 
   /// Hash to decode
   final String hash;
@@ -53,7 +50,7 @@ class BlurHash extends StatefulWidget {
   final int decodingHeight;
 
   /// Remote resource to download
-  final String image;
+  final String? image;
 
   final Duration duration;
 
@@ -64,9 +61,9 @@ class BlurHash extends StatefulWidget {
 }
 
 class BlurHashState extends State<BlurHash> {
-  Future<ui.Image> _image;
-  bool loaded;
-  bool loading;
+  late Future<ui.Image> _image;
+  late bool loaded;
+  late bool loading;
 
   @override
   void initState() {
@@ -105,13 +102,13 @@ class BlurHashState extends State<BlurHash> {
         alignment: Alignment.center,
         children: [
           buildBlurHashBackground(),
-          if (widget.image != null) prepareDisplayedImage(),
+          if (widget.image != null) prepareDisplayedImage(widget.image!),
         ],
       );
 
-  Widget prepareDisplayedImage() =>
-      Image.network(widget.image, fit: widget.imageFit, loadingBuilder:
-          (BuildContext context, Widget img, ImageChunkEvent loadingProgress) {
+  Widget prepareDisplayedImage(String image) =>
+      Image.network(image, fit: widget.imageFit, loadingBuilder:
+          (BuildContext context, Widget img, ImageChunkEvent? loadingProgress) {
         // Download started
         if (loading == false) {
           loading = true;
@@ -136,7 +133,7 @@ class BlurHashState extends State<BlurHash> {
   Widget buildBlurHashBackground() => FutureBuilder<ui.Image>(
         future: _image,
         builder: (ctx, snap) => snap.hasData
-            ? Image(image: UiImage(snap.data), fit: widget.imageFit)
+            ? Image(image: UiImage(snap.data!), fit: widget.imageFit)
             : Container(color: widget.color),
       );
 }
@@ -147,15 +144,12 @@ class _DisplayImage extends StatefulWidget {
   final Duration duration;
   final Curve curve;
 
-  const _DisplayImage(
-      {@required this.child,
-      this.duration = const Duration(milliseconds: 800),
-      this.curve,
-      Key key})
-      : assert(duration != null),
-        assert(curve != null),
-        assert(child != null),
-        super(key: key);
+  const _DisplayImage({
+    required this.child,
+    this.duration = const Duration(milliseconds: 800),
+    required this.curve,
+    Key? key,
+  }) : super(key: key);
 
   @override
   _DisplayImageState createState() => _DisplayImageState();
@@ -163,8 +157,8 @@ class _DisplayImage extends StatefulWidget {
 
 class _DisplayImageState extends State<_DisplayImage>
     with SingleTickerProviderStateMixin {
-  Animation<double> opacity;
-  AnimationController controller;
+  late Animation<double> opacity;
+  late AnimationController controller;
 
   @override
   Widget build(BuildContext context) => FadeTransition(
@@ -192,15 +186,15 @@ class UiImage extends ImageProvider<UiImage> {
   final ui.Image image;
   final double scale;
 
-  const UiImage(this.image, {this.scale = 1.0})
-      : assert(image != null),
-        assert(scale != null);
+  const UiImage(this.image, {this.scale = 1.0});
 
   @override
-  Future<UiImage> obtainKey(ImageConfiguration configuration) => SynchronousFuture<UiImage>(this);
+  Future<UiImage> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<UiImage>(this);
 
   @override
-  ImageStreamCompleter load(UiImage key, DecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
+  ImageStreamCompleter load(UiImage key, DecoderCallback decode) =>
+      OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(UiImage key) async {
     assert(key == this);
@@ -218,5 +212,6 @@ class UiImage extends ImageProvider<UiImage> {
   int get hashCode => hashValues(image.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${describeIdentity(image)}, scale: $scale)';
+  String toString() =>
+      '$runtimeType(${describeIdentity(image)}, scale: $scale)';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/fluttercommunity/flutter_blurhash
 maintainer: Robert Felker (@Solido)
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
+ Update lower Dart SDK bound to 2.12 (works with Flutter 1.25 beta)
+ Provide some type information where it's missing
+ Adjust for nullable types