### PR TITLE
Fixed Cannot clone a disposed image

### DIFF
--- a/lib/src/blurhash_widget.dart
+++ b/lib/src/blurhash_widget.dart
@@ -151,8 +151,13 @@ class BlurHashState extends State<BlurHash> {
   /// Decode the blurhash then display the resulting Image
   Widget buildBlurHashBackground() => FutureBuilder<ui.Image>(
         future: _image,
-        builder: (ctx, snap) =>
-            snap.hasData ? Image(image: UiImage(snap.data!), fit: widget.imageFit) : Container(color: widget.color),
+        builder: (ctx, snap) => snap.hasData
+            ? Image(
+                image: UiImage(snap.data!),
+                fit: widget.imageFit,
+                errorBuilder: widget.errorBuilder,
+              )
+            : Container(color: widget.color),
       );
 }
 
@@ -175,7 +180,8 @@ class _DisplayImage extends StatefulWidget {
   _DisplayImageState createState() => _DisplayImageState();
 }
 
-class _DisplayImageState extends State<_DisplayImage> with SingleTickerProviderStateMixin {
+class _DisplayImageState extends State<_DisplayImage>
+    with SingleTickerProviderStateMixin {
   late Animation<double> opacity;
   late AnimationController controller;
 
@@ -212,10 +218,12 @@ class UiImage extends ImageProvider<UiImage> {
   const UiImage(this.image, {this.scale = 1.0});
 
   @override
-  Future<UiImage> obtainKey(ImageConfiguration configuration) => SynchronousFuture<UiImage>(this);
+  Future<UiImage> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<UiImage>(this);
 
   @override
-  ImageStreamCompleter load(UiImage key, DecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
+  ImageStreamCompleter load(UiImage key, DecoderCallback decode) =>
+      OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(UiImage key) async {
     assert(key == this);
@@ -233,5 +241,6 @@ class UiImage extends ImageProvider<UiImage> {
   int get hashCode => hashValues(image.hashCode, scale);
 
   @override
-  String toString() => '$runtimeType(${describeIdentity(image)}, scale: $scale)';
+  String toString() =>
+      '$runtimeType(${describeIdentity(image)}, scale: $scale)';
 }


### PR DESCRIPTION
Because Image widget in buildBlurHashBackground does not have errorBuilder, its causing the framework to throw errors as per issues:

1. https://github.com/fluttercommunity/flutter_blurhash/issues/46
2. https://github.com/fluttercommunity/flutter_blurhash/issues/40

Kindly merge this.

Thanks,