### PR TITLE
fix deprecations

### DIFF
--- a/lib/src/blurhash.dart
+++ b/lib/src/blurhash.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';

--- a/lib/src/blurhash_image.dart
+++ b/lib/src/blurhash_image.dart
@@ -29,7 +29,7 @@ class BlurHashImage extends ImageProvider<BlurHashImage> {
   Future<BlurHashImage> obtainKey(ImageConfiguration configuration) => SynchronousFuture<BlurHashImage>(this);
 
   @override
-  ImageStreamCompleter load(BlurHashImage key, DecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
+  ImageStreamCompleter loadImage(BlurHashImage key, ImageDecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(BlurHashImage key) async {
     assert(key == this);
@@ -48,7 +48,7 @@ class BlurHashImage extends ImageProvider<BlurHashImage> {
       : other is BlurHashImage && other.blurHash == blurHash && other.scale == scale;
 
   @override
-  int get hashCode => hashValues(blurHash.hashCode, scale);
+  int get hashCode => Object.hash(blurHash.hashCode, scale);
 
   @override
   String toString() => '$runtimeType($blurHash, scale: $scale)';

--- a/lib/src/blurhash_widget.dart
+++ b/lib/src/blurhash_widget.dart
@@ -215,7 +215,7 @@ class UiImage extends ImageProvider<UiImage> {
   Future<UiImage> obtainKey(ImageConfiguration configuration) => SynchronousFuture<UiImage>(this);
 
   @override
-  ImageStreamCompleter load(UiImage key, DecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
+  ImageStreamCompleter loadImage(UiImage key, ImageDecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(UiImage key) async {
     assert(key == this);
@@ -230,7 +230,7 @@ class UiImage extends ImageProvider<UiImage> {
   }
 
   @override
-  int get hashCode => hashValues(image.hashCode, scale);
+  int get hashCode => Object.hash(image.hashCode, scale);
 
   @override
   String toString() => '$runtimeType(${describeIdentity(image)}, scale: $scale)';


### PR DESCRIPTION
Resolves the deprecations of `hashValues` and `ImageProvider.load`.

Fixes #57