### PR TITLE
Add repository to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_blurhash
 description: Compact representation of a placeholder for an image. Encode a blurry image under 30 caracters for instant display like used by Medium
 version: 0.7.0
 homepage: https://github.com/fluttercommunity/flutter_blurhash
+repository: https://github.com/fluttercommunity/flutter_blurhash
 maintainer: Robert Felker (@Solido)
 
 environment:


### PR DESCRIPTION
Not having the repository specified in `pubspec.yaml` creates difficulties obtaining the source code when navigating pub.dev. This commit adds the repository key to the package specification so that it can be properly parsed and displayed by pub.